### PR TITLE
Fix incorrect file paths in Pure Pursuit code

### DIFF
--- a/scripts/adaptive_lookahead.py
+++ b/scripts/adaptive_lookahead.py
@@ -17,7 +17,7 @@ sectors = []
 decision_pub  = rospy.Publisher('/{}/purepursuit_control/adaptive_lookahead'.format(car_name), String, queue_size = 1)
 
 def construct_path():
-    file_path = os.path.expanduser('~/catkin_ws/src/f1tenth_purepursuit/sectors/{}.csv'.format(sector_list_name))
+    file_path = os.path.join(os.path.dirname(__file__), '../sectors/{}.csv'.format(sector_list_name))
 
     with open(file_path) as csv_file:
         csv_reader = csv.reader(csv_file, delimiter = ',')

--- a/scripts/find_nearest_goal.py
+++ b/scripts/find_nearest_goal.py
@@ -36,7 +36,7 @@ plan_size    = 0
 
 def construct_path():
     global plan_size
-    file_path = os.path.expanduser('~/catkin_ws/src/f1tenth_purepursuit/path/{}.csv'.format(trajectory_name))
+    file_path = os.path.join(os.path.dirname(__file__), '../path/{}.csv'.format(trajectory_name))
 
     with open(file_path) as csv_file:
         csv_reader = csv.reader(csv_file, delimiter = ',')

--- a/scripts/find_nearest_pose.py
+++ b/scripts/find_nearest_pose.py
@@ -19,7 +19,7 @@ min_index_pub = rospy.Publisher('/{}/purepursuit_control/index_nearest_point'.fo
 min_pose_pub  = rospy.Publisher('/{}/purepursuit_control/visualize_nearest_point'.format(car_name), PoseStamped, queue_size = 1)
 
 def construct_path():
-    file_path = os.path.expanduser('~/catkin_ws/src/f1tenth_purepursuit/path/{}.csv'.format(trajectory_name))
+    file_path = os.path.join(os.path.dirname(__file__), '../path/{}.csv'.format(trajectory_name))
 
     with open(file_path) as csv_file:
         csv_reader = csv.reader(csv_file, delimiter = ',')

--- a/utils/trajectory_visualizer.py
+++ b/utils/trajectory_visualizer.py
@@ -17,7 +17,7 @@ sectors  = []
 frame_id = 'map'
 
 def get_plan():
-    file_path = os.path.expanduser('~/catkin_ws/src/f1tenth_purepursuit/path/{}.csv'.format(trajectory_name))
+    file_path = os.path.join(os.path.dirname(__file__), '../path/{}.csv'.format(trajectory_name))
     with open(file_path) as csv_file:
         csv_reader = csv.reader(csv_file, delimiter = ',')
         for waypoint in csv_reader:
@@ -27,7 +27,7 @@ def get_plan():
             plan[index][point] = float(plan[index][point])
 
 def get_sectors():
-    file_path = os.path.expanduser('~/catkin_ws/src/f1tenth_purepursuit/sectors/{}.csv'.format(sector_list))
+    file_path = os.path.join(os.path.dirname(__file__), '../sectors/{}.csv'.format(sector_list))
     with open(file_path) as csv_file:
         csv_reader = csv.reader(csv_file, delimiter = ',')
         for sector in csv_reader:


### PR DESCRIPTION
This PR fixes #5. With these changes, pure pursuit should work out of the box for people following the tutorials.

As I described this in the issue thread, the python code reads the racing line data from files which don't exist in the local directory structure if one follows the installation instructions.

The package is obviously called `simulator` and not `f1tenth_purepursuit`, so that needed to be changed. The racing line files are in the `simulator` package, so it makes sense to me to change the file paths to be relative to these script files and not absolute. I don't think that everybody puts their code into `~/catkin_ws/src/simulator`, especially if they have multiple projects and therefore multiple workspaces locally.